### PR TITLE
Clarified need for {qos:1} in publish statement of offline example...

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -167,7 +167,7 @@ html
           code(data-bespoke-autorun).language-javascript.
             var client = mqtt.createClient();
 
-            client.publish("mqtt/offline", "hello world!",
+            client.publish("mqtt/offline", "hello world!", {qos:1},
               function() {
 
               alert("publish done!");


### PR DESCRIPTION
…on slide [15 of MQTT and Node](http://mcollina.github.io/mqtt_and_nodejs/#15).  Since I'm new to MQTT, the lack of this QoS setting [confused me](http://stackoverflow.com/questions/34914317/troubles-with-offline-messages-using-mqtt-js-and-mosca) and so I've added it.
